### PR TITLE
:bug: Minor Bug Fixes

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,6 +111,20 @@ def test_transcode_svs_to_tiff(samples_path, tmp_path):
     assert result.exit_code == 0
 
 
+def test_transcode_dicom_to_tiff(samples_path, tmp_path):
+    """Test the CLI for transcoding DICOM to (tiled) TIFF."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        in_path = str(samples_path / "CMU-1-Small-Region")
+        out_path = str(Path(td) / "CMU-1-Small-Region.tiff")
+        result = runner.invoke(
+            cli.transcode,
+            ["-i", in_path, "-o", out_path],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+
+
 def test_convert_jp2_to_tiff(samples_path, tmp_path):
     """Test the CLI for converting JP2 to tiled TIFF."""
     runner = CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,139 @@
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from wsic import cli
+
+
+def test_convert_timeout(samples_path, tmp_path):
+    """Check that CLI convert raises IOError when reading times out."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        in_path = str(samples_path / "XYC.jp2")
+        out_path = str(Path(td) / "XYC.tiff")
+        warnings.simplefilter("ignore")
+        with pytest.raises(IOError, match="timed out"):
+            runner.invoke(
+                cli.convert,
+                ["-i", in_path, "-o", out_path, "--timeout", "0"],
+                catch_exceptions=False,
+            )
+
+
+def test_thumbnail(samples_path, tmp_path):
+    """Check that CLI thumbnail works."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        in_path = samples_path / "XYC.jp2"
+        out_path = Path(td) / "XYC.jpeg"
+        runner.invoke(
+            cli.thumbnail,
+            ["-i", str(in_path), "-o", str(out_path), "-s", "512", "512"],
+            catch_exceptions=False,
+        )
+        assert out_path.exists()
+        assert out_path.is_file()
+        assert out_path.stat().st_size > 0
+
+
+def test_thumbnail_downsample(samples_path, tmp_path):
+    """Check that CLI thumbnail works with downsample option."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        in_path = samples_path / "XYC.jp2"
+        out_path = Path(td) / "XYC.jpeg"
+        result = runner.invoke(
+            cli.thumbnail,
+            ["-i", str(in_path), "-o", str(out_path), "-d", "16"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert out_path.exists()
+        assert out_path.is_file()
+        assert out_path.stat().st_size > 0
+
+
+def test_thumbnail_no_cv2(samples_path, tmp_path, monkeypatch):
+    """Check that CLI thumbnail works without OpenCV (cv2)."""
+    monkeypatch.setitem(sys.modules, "cv2", None)
+    with pytest.raises(ImportError):
+        import cv2  # noqa # skipcq
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        in_path = samples_path / "XYC.jp2"
+        out_path = Path(td) / "XYC.jpeg"
+        runner.invoke(
+            cli.thumbnail,
+            ["-i", str(in_path), "-o", str(out_path), "-s", "512", "512"],
+            catch_exceptions=False,
+        )
+        assert out_path.exists()
+        assert out_path.is_file()
+        assert out_path.stat().st_size > 0
+
+
+def test_help():
+    """Test the help output."""
+    runner = CliRunner()
+    help_result = runner.invoke(cli.main, ["--help"])
+    assert help_result.exit_code == 0
+    assert "Console script for wsic." in help_result.output
+
+
+def test_transcode_svs_to_zarr(samples_path, tmp_path):
+    """Test the CLI for transcoding SVS to zarr."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        in_path = str(samples_path / "CMU-1-Small-Region.svs")
+        out_path = str(Path(td) / "CMU-1-Small-Region.zarr")
+        result = runner.invoke(
+            cli.transcode,
+            ["-i", in_path, "-o", out_path],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+
+
+def test_transcode_svs_to_tiff(samples_path, tmp_path):
+    """Test the CLI for transcoding SVS to (tiled) TIFF."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        in_path = str(samples_path / "CMU-1-Small-Region.svs")
+        out_path = str(Path(td) / "CMU-1-Small-Region.tiff")
+        result = runner.invoke(
+            cli.transcode,
+            ["-i", in_path, "-o", out_path],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+
+
+def test_convert_jp2_to_tiff(samples_path, tmp_path):
+    """Test the CLI for converting JP2 to tiled TIFF."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        in_path = str(samples_path / "XYC.jp2")
+        out_path = str(Path(td) / "XYC.tiff")
+        result = runner.invoke(
+            cli.convert,
+            ["-i", in_path, "-o", out_path],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+
+
+def test_convert_jp2_to_zarr(samples_path, tmp_path):
+    """Test the CLI for converting JP2 to zarr."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        in_path = str(samples_path / "XYC.jp2")
+        out_path = str(Path(td) / "XYC.zarr")
+        result = runner.invoke(
+            cli.convert,
+            ["-i", in_path, "-o", out_path],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -151,3 +151,32 @@ def test_convert_jp2_to_zarr(samples_path, tmp_path):
             catch_exceptions=False,
         )
     assert result.exit_code == 0
+
+
+def test_transcode_bad_input_file_ext(samples_path, tmp_path):
+    """Test the CLI for transcoding with a bad input file extension."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        # in_path must exists but not be a valid input
+        in_path = str(samples_path / "XYC.jp2")
+        out_path = str(Path(td) / "XYC.tiff")
+        result = runner.invoke(
+            cli.transcode,
+            ["-i", in_path, "-o", out_path],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 2
+
+
+def test_transcode_bad_output_file_ext(samples_path, tmp_path):
+    """Check that CLI raises click.BadParameter when output file extension is bad."""
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        in_path = samples_path / "XYC-half-mpp.tiff"
+        out_path = Path(td) / "XYC.foo"
+        result = runner.invoke(
+            cli.transcode,
+            ["-i", str(in_path), "-o", str(out_path)],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 2

--- a/wsic/cli.py
+++ b/wsic/cli.py
@@ -254,7 +254,7 @@ def transcode(
     else:
         suffixes = "".join(in_path.suffixes)
         raise click.BadParameter(
-            f"Input file type {suffixes} could not be transcribed", param_hint="in_path"
+            f"Input file type {suffixes} could not be transcoded", param_hint="in_path"
         )
     if out_path.suffix == ".zarr":
         writer = wsic.writers.ZarrWriter(

--- a/wsic/cli.py
+++ b/wsic/cli.py
@@ -250,7 +250,7 @@ def transcode(
     if ("tiff",) in file_types:
         reader = wsic.readers.TIFFReader(in_path)
     elif ("dicom",) in file_types or ("dcm",) in file_types:
-        reader = wsic.readers.DICOMReader(in_path)
+        reader = wsic.readers.DICOMWSIReader(in_path)
     else:
         suffixes = "".join(in_path.suffixes)
         raise click.BadParameter(

--- a/wsic/cli.py
+++ b/wsic/cli.py
@@ -256,11 +256,25 @@ def transcode(
         raise click.BadParameter(
             f"Input file type {suffixes} could not be transcribed", param_hint="in_path"
         )
-    writer = wsic.writers.ZarrWriter(
-        out_path,
-        tile_size=reader.tile_shape[::-1],
-        dtype=reader.dtype,
-    )
+    if out_path.suffix == ".zarr":
+        writer = wsic.writers.ZarrWriter(
+            out_path,
+            shape=reader.shape,
+            tile_size=reader.tile_shape[::-1],
+            dtype=reader.dtype,
+        )
+    elif out_path.suffix == ".tiff":
+        writer = wsic.writers.TIFFWriter(
+            out_path,
+            shape=reader.shape,
+            tile_size=reader.tile_shape[::-1],
+            dtype=reader.dtype,
+        )
+    else:
+        raise click.BadParameter(
+            f"Output file type {out_path.suffix} not supported",
+            param_hint="out_path",
+        )
     writer.transcode_from_reader(reader)
 
 

--- a/wsic/utils.py
+++ b/wsic/utils.py
@@ -483,8 +483,9 @@ def resize_array(
         }
         cv2_interpolation = str_to_cv2_interpolation[interpolation]
 
+        out_size = tuple(int(x) for x in shape[::-1])
         return cv2.resize(
-            array, shape[::-1], interpolation=cv2_interpolation, **(cv2_kwargs or {})
+            array, out_size, interpolation=cv2_interpolation, **(cv2_kwargs or {})
         )
 
     with suppress(ImportError):

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -318,6 +318,7 @@ class JP2Writer(Writer):
         pyramid_downsamples: Optional[List[int]] = None,
         overwrite: bool = False,
         verbose: bool = False,
+        **kwargs,
     ) -> None:
         if codec != "jpeg2000":
             warn_unused(codec)

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -488,7 +488,7 @@ class TIFFWriter(Writer):
         overwrite: bool = False,
         verbose: bool = False,
         *,
-        ome: bool = True,
+        ome: bool = False,
     ) -> None:
         if dtype is not np.uint8:
             warn_unused(dtype)


### PR DESCRIPTION
Fix a colletion of minor bugs:
- Missing **kwargs for init
- Ensure cv2 arg is an int tuple (not floats etc).
- Add switching of writer based on file extension for TIFF and Zarr.
- Fixes a bug when using CLI for transcoding / repackaging from DICOM.