### PR TITLE
:bug: Write NGFF Resolution

### DIFF
--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -1212,7 +1212,6 @@ class ZarrWriter(Writer, Reader):
                                 ngff.CoordinateTransformation(
                                     "scale",
                                     [
-                                        1,
                                         self.microns_per_pixel[0] * downsample,
                                         self.microns_per_pixel[1] * downsample,
                                     ],


### PR DESCRIPTION
Add support for writing MPP metadata when writing an NGFF v0.4 Zarr.