### PR TITLE
:bug: Use Reader Tile Size For Transcode To TIFF

### DIFF
--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -672,6 +672,12 @@ class TIFFWriter(Writer):
         reader: Union[TIFFReader, DICOMWSIReader],
         downsample_method: Optional[str] = None,
     ) -> None:
+        # Validate input
+        if not reader.tile_shape:
+            raise ValueError(
+                "Reader must have a known tile shape/size and implement get_tile."
+            )
+
         import tifffile
 
         microns_per_pixel = self.microns_per_pixel or reader.microns_per_pixel
@@ -685,7 +691,7 @@ class TIFFWriter(Writer):
             else None
         )
 
-        tile_size = reader.tile_shape[:2][::-1] or self.tile_size
+        tile_size = reader.tile_shape[:2][::-1]
         reader_mosaic_shape = mosaic_shape(reader.shape[:2], tile_size)
         tile_generator = (
             reader.get_tile(tile_index, decode=False)

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -685,7 +685,8 @@ class TIFFWriter(Writer):
             else None
         )
 
-        reader_mosaic_shape = mosaic_shape(reader.shape[:2], self.tile_size)
+        tile_size = reader.tile_shape[:2][::-1] or self.tile_size
+        reader_mosaic_shape = mosaic_shape(reader.shape[:2], tile_size)
         tile_generator = (
             reader.get_tile(tile_index, decode=False)
             for tile_index in np.ndindex(reader_mosaic_shape)


### PR DESCRIPTION
Copy the tile size from the reader object when transcoding to TIFF unless a tile size is specified at init.