### PR TITLE
:sparkles: Validation & Handle Negative Index Wrap

### DIFF
--- a/wsic/utils.py
+++ b/wsic/utils.py
@@ -48,7 +48,6 @@ def downsample_shape(
     return tuple(rounding_func(x / s) for x, s in zip(baseline_shape, downsample))
 
 
-
 def block_downsample_shape(
     shape: Tuple[int, ...], downsample: float, block_shape: Tuple[int, ...]
 ) -> Tuple[int, ...]:


### PR DESCRIPTION
1. The function now raises a ValueError if the downsample factor is not greater than 0 - `downsample_shape`
2. `wrap_index` includes handling negative indices and indices that exceed the bounds of the array.
3. `view_as_blocks` includes checking that the block shape is a divisor of the array shape to avoid errors, and removing the unnecessary numpy.ravel() call.