### PR TITLE
🚑 Fix `DICOMWSIReader` Requiring Interactive Input

### DIFF
--- a/wsic/cli.py
+++ b/wsic/cli.py
@@ -208,6 +208,11 @@ def convert(
     in_path = Path(in_path)
     out_path = Path(out_path)
     reader = wsic.readers.Reader.from_file(in_path)
+
+    # Special case for DICOMWSIReader
+    if isinstance(reader, wsic.readers.DICOMWSIReader):
+        reader.performance_check()
+
     writer_cls = get_writer_class(out_path, writer)
     writer = writer_cls(
         out_path,
@@ -261,6 +266,7 @@ def transcode(
         reader = wsic.readers.DICOMWSIReader(
             in_path,
         )
+        reader.performance_check()
     else:
         suffixes = "".join(in_path.suffixes)
         raise click.BadParameter(

--- a/wsic/readers.py
+++ b/wsic/readers.py
@@ -547,7 +547,6 @@ class DICOMWSIReader(Reader):
         self.slide = WsiDicom.open(self.path)
         # Cancel the timer if it hasn't already fired
         timer.cancel()
-        self.performance_check()
         channels = len(self.slide.read_tile(0, (0, 0)).getbands())
         self.shape = (self.slide.size.height, self.slide.size.width, channels)
         self.dtype = np.uint8


### PR DESCRIPTION
Critial hotfix to address and issue where initializing `DICOMWSIReader` required user input which preventing creation of readers in subprocesses.