### PR TITLE
:art: Improve DICOM Reader Slow Init Warning

### DIFF
--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -1109,7 +1109,7 @@ class SVSWriter(Writer):
                         tile_generator = self.level_progress(
                             tile_generator,
                             total=int(np.product(level_tiles_shape)),
-                            desc=f"Level {level}",
+                            desc=f"Level {level + 1}",
                             leave=False,
                         )
 


### PR DESCRIPTION
- Refactors the timeout warning to a generic context manger for timed-out warnings.
- Only shows the warning from the main process (to avoid output spam).