### PR TITLE
🚸 Add Better Validation To TIFF Write Arguments

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,9 +3,9 @@
 ## 0.8.2 (2023-04-02)
 
 - Bug fixes:
-    - Fix issue where `DICOMWSIReader` required user input at init.
-    - Fix level offset when printing the level number during `TIFFWriter` pyramid building.
-    - Refactor slow `DICOMWSIReader` init warning and only warn from the main process.
+  - Fix issue where `DICOMWSIReader` required user input at init.
+  - Fix level offset when printing the level number during `TIFFWriter` pyramid building.
+  - Refactor slow `DICOMWSIReader` init warning and only warn from the main process.
 
 ## 0.8.0 (2023-04-01)
 

--- a/tests/test_wsic.py
+++ b/tests/test_wsic.py
@@ -253,6 +253,7 @@ def test_jp2_to_webp_tiled_tiff(samples_path, tmp_path):
             tile_size=(256, 256),
             codec="WebP",
             compression_level=-1,  # <0 for lossless
+            microns_per_pixel=(0.5, 0.5),  # input has no resolution box
         )
         writer.copy_from_reader(reader=reader, num_workers=3, read_tile_size=(512, 512))
 

--- a/tests/test_wsic.py
+++ b/tests/test_wsic.py
@@ -28,6 +28,7 @@ def test_jp2_to_deflate_tiled_tiff(samples_path, tmp_path):
             overwrite=False,
             tile_size=(256, 256),
             codec="deflate",
+            microns_per_pixel=(0.5, 0.5),  # the input .jp2 has no resolution box
         )
         writer.copy_from_reader(reader=reader, num_workers=3, read_tile_size=(512, 512))
 
@@ -54,6 +55,7 @@ def test_jp2_to_deflate_pyramid_tiff(samples_path, tmp_path):
             tile_size=(256, 256),
             codec="deflate",
             pyramid_downsamples=pyramid_downsamples,
+            microns_per_pixel=(0.5, 0.5),  # the input .jp2 has no resolution box
         )
         writer.copy_from_reader(reader=reader, num_workers=3, read_tile_size=(512, 512))
 
@@ -94,6 +96,7 @@ def test_no_tqdm(samples_path, tmp_path, monkeypatch):
             tile_size=(256, 256),
             codec="deflate",
             pyramid_downsamples=pyramid_downsamples,
+            microns_per_pixel=(0.5, 0.5),  # the input .jp2 has no resolution box
         )
         writer.copy_from_reader(reader=reader, num_workers=3, read_tile_size=(512, 512))
 

--- a/wsic/dicom.py
+++ b/wsic/dicom.py
@@ -432,7 +432,8 @@ def create_vl_wsi_dataset(
         tile_size:
             The size of tiles in pixels as a tuple of (width, height).
         microns_per_pixel:
-            The microns per pixel as a tuple of (x, y).
+            The microns per pixel as a tuple of (x, y). Defaults to
+            (1, 1) pixels per mm (1000 microns per pixel).
         photometric_interpretation:
             The photometric interpretation of the image.
 
@@ -442,11 +443,15 @@ def create_vl_wsi_dataset(
         raise ValueError("size must be a tuple of (width, height)")
     if len(tile_size) != 2:
         raise ValueError("tile_size must be a tuple of (width, height)")
-    if len(microns_per_pixel) != 2:
+    if microns_per_pixel and len(microns_per_pixel) != 2:
         raise ValueError("microns_per_pixel must be a tuple of (x, y)")
 
     # Convert MPP to mm spacing
-    pixels_per_mm = [1 / mpp2ppu(x, "mm") for x in microns_per_pixel]
+    pixels_per_mm = (
+        [1 / mpp2ppu(x, "mm") for x in microns_per_pixel]
+        if microns_per_pixel
+        else (1, 1)
+    )
 
     # Calculate mosaic size
     mosaic_size = (

--- a/wsic/validation.py
+++ b/wsic/validation.py
@@ -1,0 +1,58 @@
+"""Functions used for data validation."""
+import warnings
+
+from utils import mpp2ppu
+
+
+def check_mpp(mpp: float, warn: bool = True) -> bool:
+    sensible = True
+    # Convert to other units
+    ppcm = mpp2ppu(mpp, "cm")
+    ppmm = mpp2ppu(mpp, "mm")
+    ppi = mpp2ppu(mpp, "inch")
+    # Check that microns-per-pixel (MPP) is a sensible value.
+    # Sensible values of MPP for a whole slide image are:
+    #  1, 0.5, 0.25 etc.
+    # Common values for documents in pixels-per-inch (PPI) are:
+    #   72, 150, 300, 600, 1_200, 2_400
+    # In MPP
+    if ppmm == 1:
+        warnings.warn(
+            "Resolution in pixels-per-mm is the value 1."
+            "This may not be a sensible value for a WSI. "
+            "It may be a default set by other software. ",
+            stacklevel=3,
+        )
+        sensible = False
+    if ppcm == 1:
+        warnings.warn(
+            "Resolution in pixels-per-cm is the value 1."
+            "This may not be a sensible value for a WSI. "
+            "It may be a default set by other software. ",
+            stacklevel=3,
+        )
+        sensible = False
+    if ppi == 1:
+        warnings.warn(
+            "Resolution in pixels-per-inch (PPI) is the value 1."
+            "This may not be a sensible value for a WSI. "
+            "It may be a default set by other software. ",
+            stacklevel=3,
+        )
+        sensible = False
+    if ppi in (72, 150, 300, 1_200, 2_400):
+        warnings.warn(
+            "Resolution in pixels-per-inch (PPI) is a common value for "
+            "print documents. "
+            "This may not be a sensible value for a WSI. "
+            "It may be a default set by other software.",
+            stacklevel=3,
+        )
+        sensible = False
+    if mpp > 5:
+        warnings.warn(
+            "Resolution is unusually low for a WSI. ",
+            stacklevel=3,
+        )
+        sensible = False
+    return sensible  # noqa: R504

--- a/wsic/validation.py
+++ b/wsic/validation.py
@@ -4,7 +4,7 @@ import warnings
 from utils import mpp2ppu
 
 
-def check_mpp(mpp: float, warn: bool = True) -> bool:
+def check_mpp(mpp: float, warn: bool = True) -> bool:  # noqa: CCR001
     sensible = True
     # Convert to other units
     ppcm = mpp2ppu(mpp, "cm")
@@ -17,42 +17,47 @@ def check_mpp(mpp: float, warn: bool = True) -> bool:
     #   72, 150, 300, 600, 1_200, 2_400
     # In MPP
     if ppmm == 1:
-        warnings.warn(
-            "Resolution in pixels-per-mm is the value 1."
-            "This may not be a sensible value for a WSI. "
-            "It may be a default set by other software. ",
-            stacklevel=3,
-        )
+        if warn:
+            warnings.warn(
+                "Resolution in pixels-per-mm is the value 1."
+                "This may not be a sensible value for a WSI. "
+                "It may be a default set by other software. ",
+                stacklevel=3,
+            )
         sensible = False
     if ppcm == 1:
-        warnings.warn(
-            "Resolution in pixels-per-cm is the value 1."
-            "This may not be a sensible value for a WSI. "
-            "It may be a default set by other software. ",
-            stacklevel=3,
-        )
+        if warn:
+            warnings.warn(
+                "Resolution in pixels-per-cm is the value 1."
+                "This may not be a sensible value for a WSI. "
+                "It may be a default set by other software. ",
+                stacklevel=3,
+            )
         sensible = False
     if ppi == 1:
-        warnings.warn(
-            "Resolution in pixels-per-inch (PPI) is the value 1."
-            "This may not be a sensible value for a WSI. "
-            "It may be a default set by other software. ",
-            stacklevel=3,
-        )
+        if warn:
+            warnings.warn(
+                "Resolution in pixels-per-inch (PPI) is the value 1."
+                "This may not be a sensible value for a WSI. "
+                "It may be a default set by other software. ",
+                stacklevel=3,
+            )
         sensible = False
     if ppi in (72, 150, 300, 1_200, 2_400):
-        warnings.warn(
-            "Resolution in pixels-per-inch (PPI) is a common value for "
-            "print documents. "
-            "This may not be a sensible value for a WSI. "
-            "It may be a default set by other software.",
-            stacklevel=3,
-        )
+        if warn:
+            warnings.warn(
+                "Resolution in pixels-per-inch (PPI) is a common value for "
+                "print documents. "
+                "This may not be a sensible value for a WSI. "
+                "It may be a default set by other software.",
+                stacklevel=3,
+            )
         sensible = False
     if mpp > 5:
-        warnings.warn(
-            "Resolution is unusually low for a WSI. ",
-            stacklevel=3,
-        )
+        if warn:
+            warnings.warn(
+                "Resolution is unusually low for a WSI. ",
+                stacklevel=3,
+            )
         sensible = False
     return sensible  # noqa: R504

--- a/wsic/validation.py
+++ b/wsic/validation.py
@@ -1,7 +1,7 @@
 """Functions used for data validation."""
 import warnings
 
-from utils import mpp2ppu
+from wsic.utils import mpp2ppu
 
 
 def check_mpp(mpp: float, warn: bool = True) -> bool:  # noqa: CCR001

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -757,8 +757,8 @@ class TIFFWriter(Writer):
         resolution: Optional[Tuple[float, float]] = None,
     ) -> None:
         """Validate write arguments."""
-        from utils import ppu2mpp
-        from validation import check_mpp
+        from wsic.utils import ppu2mpp
+        from wsic.validation import check_mpp
 
         # Check that tile size is a multiple of 16
         if any(s % 16 for s in tile_size):

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -1901,7 +1901,7 @@ class DICOMWSIWriter(Writer):
     def validate_write_args(
         microns_per_pixel: Optional[Tuple[float, float]],
     ):
-        from validation import check_mpp
+        from wsic.validation import check_mpp
 
         if microns_per_pixel is None:
             warnings.warn(

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -757,58 +757,16 @@ class TIFFWriter(Writer):
         resolution: Optional[Tuple[float, float]] = None,
     ) -> None:
         """Validate write arguments."""
+        from utils import ppu2mpp
+        from validation import check_mpp
+
         # Check that tile size is a multiple of 16
         if any(s % 16 for s in tile_size):
             raise ValueError(
                 "Tile size must be a multiple of 16 pixels for a TIFF file."
             )
-        # Check that resolution is sensible.
-        # TIFF resolution specified pixels per cm (PPCM) here,
-        # although it can also be written as pixels per inch (PPI).
-        # Senseible values for a WSI will be large, such as:
-        #  10_000, 20_000, 40_000
-        # which correspond to the microns-per-pixel (MPP) values:
-        #   1, 0.5, 0.25
-        # Common values for documents in PPI are:
-        #   72, 150, 300, 600, 1_200, 2_400
-        # In PPCM these are:
-        #   28.35, 59.06, 118.1, 236.2, 472.4, 944.9
-        if resolution is None:
-            warnings.warn(
-                "No resolution specified for output. "
-                "Resolution is a required field for a TIFF file. "
-                # This default is set by tifffile but we also set it to
-                # be sure.
-                "A default value of (1.0, 1.0) will be used.",
-                stacklevel=3,
-            )
-        elif 1 in resolution:
-            warnings.warn(
-                "Resolution contains the value 1."
-                "This may not be a sensible value for a WSI. "
-                "It may be a default set by other software. ",
-                stacklevel=3,
-            )
-        elif any(r in (72, 150, 300, 1_200, 2_400) for r in resolution):
-            warnings.warn(
-                "Resolution contains a common pixels-per-inch (PPI) value for "
-                "print documents. "
-                "This may not be a sensible value for a WSI. "
-                "It may be a default set by other software.",
-                stacklevel=3,
-            )
-        elif any(round(r) in (28, 59, 118, 236, 472, 945) for r in resolution):
-            warnings.warn(
-                "Resolution contains a common pixels-per-cm value for print documents. "
-                "This may not be a sensible value for a WSI. "
-                "It may be a default set by other software.",
-                stacklevel=3,
-            )
-        elif any(r < 5_000 for r in resolution):
-            warnings.warn(
-                "Resolution is unusually low for a WSI. ",
-                stacklevel=3,
-            )
+        for r in resolution:
+            check_mpp(mpp=ppu2mpp(r, "cm"))
 
 
 class SVSWriter(Writer):
@@ -1943,13 +1901,19 @@ class DICOMWSIWriter(Writer):
     def validate_write_args(
         microns_per_pixel: Optional[Tuple[float, float]],
     ):
+        from validation import check_mpp
+
         if microns_per_pixel is None:
             warnings.warn(
                 "Resolution (PixelSpacing) is None but it is a required "
                 "(Type 1) attribute for DICOM VL Whole Slide Image files. "
-                "A default of (1.0, 1.0) microns-per-pixel will be used.",
+                "A default of (1.0, 1.0) microns-per-mm or "
+                "(1000, 1000) microns-per-pixel will be used.",
                 stacklevel=3,
             )
+        else:
+            for r in microns_per_pixel:
+                check_mpp(r)
 
 
 def _cv2_downsample(image: np.ndarray, factor: int) -> np.ndarray:

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -751,8 +751,8 @@ class TIFFWriter(Writer):
                 resolutionunit="centimeter" if resolution else None,
             )
 
+    @staticmethod
     def validate_write_args(
-        self,
         tile_size: Tuple[int, int],
         resolution: Optional[Tuple[float, float]] = None,
     ) -> None:

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -765,6 +765,15 @@ class TIFFWriter(Writer):
             raise ValueError(
                 "Tile size must be a multiple of 16 pixels for a TIFF file."
             )
+        # Check if resolution is present
+        if not resolution:
+            warnings.warn(
+                "No resolution data. Output file will not have any "
+                "resolution metadata.",
+                stacklevel=2,
+            )
+            return
+        # Check that resolution is a sensible value
         for r in resolution:
             check_mpp(mpp=ppu2mpp(r, "cm"))
 

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -596,6 +596,7 @@ class TIFFWriter(Writer):
             if microns_per_pixel
             else None
         )
+        tile_size = self.tile_size
 
         with ZarrIntermediate(
             None, reader.shape, zero_after_read=False
@@ -621,6 +622,10 @@ class TIFFWriter(Writer):
                     metadata["PhysicalSizeX"] = self.microns_per_pixel[0]
                     metadata["PhysicalSizeY"] = self.microns_per_pixel[1]
 
+                self.validate_write_args(
+                    tile_size=tile_size,
+                    resolution=resolution,
+                )
                 tif.write(
                     data=iter(reader_tile_iterator),
                     tile=self.tile_size,
@@ -669,11 +674,7 @@ class TIFFWriter(Writer):
                             desc=f"Level {level + 1}",
                             leave=False,
                         )
-                        tile_size = self.tile_size
 
-                        self.validate_write_args(
-                            tile_size=tile_size,
-                        )
                         tif.write(
                             data=iter(tile_generator),
                             tile=tile_size,

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -21,7 +21,6 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    cast,
 )
 
 import numpy as np
@@ -1817,7 +1816,6 @@ class DICOMWSIWriter(Writer):
 
         warn_unused(downsample_method, ignore_falsey=True)
 
-        mpp = self._mpp2ppmm(self.microns_per_pixel or reader.microns_per_pixel)
         width = self.shape[1]
         height = self.shape[0]
         photometric_interpretation = (
@@ -1827,7 +1825,6 @@ class DICOMWSIWriter(Writer):
         meta, dataset = create_vl_wsi_dataset(
             size=(width, height),
             tile_size=self.tile_size,
-            microns_per_pixel=mpp,
             photometric_interpretation=photometric_interpretation,
         )
 
@@ -1888,7 +1885,6 @@ class DICOMWSIWriter(Writer):
 
         warn_unused(downsample_method, ignore_falsey=True)
 
-        mpp = self._mpp2ppmm(self.microns_per_pixel or reader.microns_per_pixel)
         width = self.shape[1]
         height = self.shape[0]
         photometric_interpretation = (
@@ -1905,7 +1901,6 @@ class DICOMWSIWriter(Writer):
         meta, dataset = create_vl_wsi_dataset(
             size=(width, height),
             tile_size=self.tile_size,
-            microns_per_pixel=mpp,
             photometric_interpretation=photometric_interpretation,
         )
 
@@ -1934,30 +1929,6 @@ class DICOMWSIWriter(Writer):
                 yield reader.get_tile(xy, decode=False)
 
         append_frames(self.path, tile_generator(), tile_count)
-
-    def _mpp2ppmm(self, mpp: Optional[Tuple[float, float]]) -> Tuple[float, float]:
-        """Convert microns per pixel to pixels per millimeter.
-
-        Args:
-            mpp:
-                An (x, y) tuple of microns per pixel.
-
-        Returns:
-            An (x, y) tuple of pixels per millimeter.
-
-        Raises:
-            A `UserWarning` if None mpp was given as input, in which
-            case a default value of 0.5 microns per pixel is used.
-        """
-        if mpp is None:
-            warnings.warn(
-                "No resolution metadata found for input or given. "
-                "This is a required attribute for writing DICOM images. "
-                "Using default microns per pixel value of 0.5.",
-                stacklevel=2,
-            )
-            mpp = (0.5, 0.5)
-        return cast(Tuple[float, float], mpp)
 
 
 def _cv2_downsample(image: np.ndarray, factor: int) -> np.ndarray:


### PR DESCRIPTION
- [x] Check that tile size is a multiple of 16 (part of TIFF 6.0 spec, see TileWidth and TileHeight tags).
- [x] Check that resolution arguments are sensible (should be very large values > 5,000 for microns per pixel and not common DPI values such as 72, 300 etc.)
- [x] Refactor resolution check logic to be used by other writers.