### PR TITLE
🐛 Fix Writing MPP For DICOM Images

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,9 +3,9 @@
 ## 0.8.2 (2023-04-02)
 
 - Bug fixes:
-    - Fix issue where `DICOMWSIReader` required user input at init.
-    - Fix level offset when printing the level number during `TIFFWriter` pyramid building.
-    - Refactor slow `DICOMWSIReader` init warning and only warn from the main process.
+  - Fix issue where `DICOMWSIReader` required user input at init.
+  - Fix level offset when printing the level number during `TIFFWriter` pyramid building.
+  - Refactor slow `DICOMWSIReader` init warning and only warn from the main process.
 
 ## 0.8.0 (2023-04-01)
 

--- a/wsic/dicom.py
+++ b/wsic/dicom.py
@@ -9,6 +9,8 @@ from typing import Iterable, List, Literal, Optional, Tuple, Union
 from pydicom.dataset import Dataset, FileMetaDataset
 from pydicom.uid import JPEGBaseline, VLWholeSlideMicroscopyImageStorage, generate_uid
 
+from wsic.utils import mpp2ppu
+
 PathLike = Union[Path, str]
 FileLike = Union[PathLike, BytesIO]
 
@@ -415,6 +417,7 @@ def brightfield_optical_path_sequence(
 def create_vl_wsi_dataset(
     size: Tuple[int, int],
     tile_size: Tuple[int, int],
+    microns_per_pixel: Tuple[float, float],
     photometric_interpretation: Literal["RGB", "YBR_FULL_422"] = "YBR_FULL_422",
 ) -> Tuple[FileMetaDataset, Dataset]:
     """Create a VL Whole Slide Microscopy Image Storage dataset.
@@ -428,10 +431,24 @@ def create_vl_wsi_dataset(
             height).
         tile_size:
             The size of tiles in pixels as a tuple of (width, height).
+        microns_per_pixel:
+            The microns per pixel as a tuple of (x, y).
         photometric_interpretation:
             The photometric interpretation of the image.
 
     """
+    # Input validation and conversion
+    if len(size) != 2:
+        raise ValueError("size must be a tuple of (width, height)")
+    if len(tile_size) != 2:
+        raise ValueError("tile_size must be a tuple of (width, height)")
+    if len(microns_per_pixel) != 2:
+        raise ValueError("microns_per_pixel must be a tuple of (x, y)")
+
+    # Convert MPP to mm spacing
+    pixels_per_mm = [1 / mpp2ppu(x, "mm") for x in microns_per_pixel]
+
+    # Calculate mosaic size
     mosaic_size = (
         ceil(size[0] / tile_size[0]),
         ceil(size[1] / tile_size[1]),
@@ -528,7 +545,7 @@ def create_vl_wsi_dataset(
     shared_functional_groups.ReferencedImageSequence = []
     pixel_measures = Dataset()
     pixel_measures.SliceThickness = 1.0  # Type 1
-    pixel_measures.PixelSpacing = [0.0016, 0.0016]  # in mm, Type 1
+    pixel_measures.PixelSpacing = pixels_per_mm  # in mm, Type 1
     shared_functional_groups.PixelMeasuresSequence = [pixel_measures]
     wsi_image_frame_type = Dataset()
     wsi_image_frame_type.FrameType = ["ORIGINAL", "PRIMARY", "VOLUME", "NONE"]  # Type 1

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -1755,6 +1755,7 @@ class DICOMWSIWriter(Writer):
         meta, dataset = create_vl_wsi_dataset(
             size=(width, height),
             tile_size=self.tile_size,
+            microns_per_pixel=self.microns_per_pixel or reader.microns_per_pixel,
             photometric_interpretation=photometric_interpretation,
         )
 
@@ -1831,6 +1832,7 @@ class DICOMWSIWriter(Writer):
         meta, dataset = create_vl_wsi_dataset(
             size=(width, height),
             tile_size=self.tile_size,
+            microns_per_pixel=self.microns_per_pixel or reader.micoins_per_pixel,
             photometric_interpretation=photometric_interpretation,
         )
 

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -1868,18 +1868,17 @@ class DICOMWSIWriter(Writer):
 
         append_frames(self.path, tile_generator(), tile_count)
 
-
-@staticmethod
-def validate_write_args(
-    microns_per_pixel: Optional[Tuple[float, float]],
-):
-    if microns_per_pixel is None:
-        warnings.warn(
-            "Resolution (PixelSpacing) is None but it is a required "
-            "(Type 1) attribute for DICOM VL Whole Slide Image files. "
-            "A default of (1.0, 1.0) microns-per-pixel will be used.",
-            stacklevel=3,
-        )
+    @staticmethod
+    def validate_write_args(
+        microns_per_pixel: Optional[Tuple[float, float]],
+    ):
+        if microns_per_pixel is None:
+            warnings.warn(
+                "Resolution (PixelSpacing) is None but it is a required "
+                "(Type 1) attribute for DICOM VL Whole Slide Image files. "
+                "A default of (1.0, 1.0) microns-per-pixel will be used.",
+                stacklevel=3,
+            )
 
 
 def _cv2_downsample(image: np.ndarray, factor: int) -> np.ndarray:

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -1832,7 +1832,7 @@ class DICOMWSIWriter(Writer):
         meta, dataset = create_vl_wsi_dataset(
             size=(width, height),
             tile_size=self.tile_size,
-            microns_per_pixel=self.microns_per_pixel or reader.micoins_per_pixel,
+            microns_per_pixel=self.microns_per_pixel or reader.microns_per_pixel,
             photometric_interpretation=photometric_interpretation,
         )
 


### PR DESCRIPTION
- [x] Fix a bug where the microns-per-pixel (actually written as a PixelSpacing DICOM attribute in mm) would not be written to DICOM images and a default values was being used instead.
- [x] Add warning about PixelSpacing being a required (Type 1) data attribute and state that a default will be used if not supplied.