### PR TITLE
✨ Add Support For Writing To Other Zarr Stores

### DIFF
--- a/tests/test_wsic.py
+++ b/tests/test_wsic.py
@@ -762,6 +762,64 @@ def test_missing_imagecodecs_codec(samples_path, tmp_path):
         )
 
 
+# Zarr tests for alternate stores
+
+
+def test_write_read_sqlite_store_zarr(samples_path, tmp_path):
+    """Test writing and reading a Zarr with an SQLite store."""
+    reader = readers.TIFFReader(samples_path / "CMU-1-Small-Region.svs")
+    writer = writers.ZarrWriter(
+        path=tmp_path / "test.zarr.sqlite",
+        shape=reader.shape,
+        store=zarr.SQLiteStore,
+    )
+    writer.copy_from_reader(reader=reader)
+    writer.close()
+
+    # SQLite doesn't have a standard file extension. Therefore it is
+    # hard to infer that the file is a SQLite file. We must pass a
+    # zarr.SQLiteStore instance to open it.
+    readers.ZarrReader(zarr.SQLiteStore(tmp_path / "test.zarr.sqlite"))
+
+
+def test_write_read_zip_store_zarr(samples_path, tmp_path):
+    """Test writing and reading a Zarr with a Zip store."""
+    reader = readers.TIFFReader(samples_path / "CMU-1-Small-Region.svs")
+    writer = writers.ZarrWriter(
+        path=tmp_path / "test.zarr.zip",
+        shape=reader.shape,
+    )
+
+    writer.copy_from_reader(reader=reader)
+    writer.close()  # Important for zip store!
+
+    readers.ZarrReader(tmp_path / "test.zarr.zip")
+
+
+def test_write_read_temp_store_zarr(samples_path):
+    """Test writing and reading a Zarr with a Temp store."""
+    reader = readers.TIFFReader(samples_path / "CMU-1-Small-Region.svs")
+    writer = writers.ZarrWriter(
+        path="test.zarr",
+        shape=reader.shape,
+        store=zarr.TempStore,
+    )
+    writer.copy_from_reader(reader=reader)
+
+    readers.ZarrReader(writer.zarr.store)
+
+
+def test_write_read_temp_store_zarr_absolute_path(samples_path):
+    """Test writing and reading a Zarr with a Temp store."""
+    reader = readers.TIFFReader(samples_path / "CMU-1-Small-Region.svs")
+    with pytest.raises(ValueError, match="absolute"):
+        writers.ZarrWriter(
+            path="/other/test.zarr",
+            shape=reader.shape,
+            store=zarr.TempStore,
+        )
+
+
 # Test Scenarios
 
 WRITER_EXT_MAPPING = {

--- a/tests/test_wsic.py
+++ b/tests/test_wsic.py
@@ -769,9 +769,8 @@ def test_write_read_sqlite_store_zarr(samples_path, tmp_path):
     """Test writing and reading a Zarr with an SQLite store."""
     reader = readers.TIFFReader(samples_path / "CMU-1-Small-Region.svs")
     writer = writers.ZarrWriter(
-        path=tmp_path / "test.zarr.sqlite",
         shape=reader.shape,
-        store=zarr.SQLiteStore,
+        store=zarr.SQLiteStore(tmp_path / "test.zarr.sqlite"),
     )
     writer.copy_from_reader(reader=reader)
     writer.close()
@@ -800,24 +799,12 @@ def test_write_read_temp_store_zarr(samples_path):
     """Test writing and reading a Zarr with a Temp store."""
     reader = readers.TIFFReader(samples_path / "CMU-1-Small-Region.svs")
     writer = writers.ZarrWriter(
-        path="test.zarr",
         shape=reader.shape,
-        store=zarr.TempStore,
+        store=zarr.TempStore("test.zarr"),
     )
     writer.copy_from_reader(reader=reader)
 
     readers.ZarrReader(writer.zarr.store)
-
-
-def test_write_read_temp_store_zarr_absolute_path(samples_path):
-    """Test writing and reading a Zarr with a Temp store."""
-    reader = readers.TIFFReader(samples_path / "CMU-1-Small-Region.svs")
-    with pytest.raises(ValueError, match="absolute"):
-        writers.ZarrWriter(
-            path="/other/test.zarr",
-            shape=reader.shape,
-            store=zarr.TempStore,
-        )
 
 
 # Test Scenarios

--- a/wsic/cli.py
+++ b/wsic/cli.py
@@ -77,7 +77,6 @@ def get_writer_class(out_path: Path, writer: str) -> wsic.writers.Writer:
 
 
 def get_store(
-    self,
     store: str,
     path: Union[str, Path],
     **store_kwargs,
@@ -85,7 +84,7 @@ def get_store(
     if store == "dir":
         return zarr.DirectoryStore(path, **store_kwargs)
     if store == "ndir":
-        return zarr.NestedDirectoryStore(self.path, **store_kwargs)
+        return zarr.NestedDirectoryStore(path, **store_kwargs)
     if store == "zip":
         return zarr.ZipStore(path, **store_kwargs)
     if store == "sqlite":

--- a/wsic/cli.py
+++ b/wsic/cli.py
@@ -251,7 +251,7 @@ def convert(
 
     extra_kwargs = {}
     if isinstance(writer_cls, wsic.writers.ZarrWriter):
-        extra_kwargs["store"] = get_store(store)
+        extra_kwargs["store"] = get_store(store, path=out_path)
 
     writer = writer_cls(
         out_path,

--- a/wsic/magic.py
+++ b/wsic/magic.py
@@ -167,6 +167,18 @@ FILE_INCANTATIONS = {
             Spell(b"DICM", 128),
         ],
     ),
+    ("zip",): Incantation(
+        spells=[
+            # ZIP signature
+            Spell(b"PK\x03\x04"),
+        ],
+    ),
+    ("sqlite3",): Incantation(
+        spells=[
+            # SQLite3 signature
+            Spell(b"SQLite format 3\x00"),
+        ],
+    ),
 }
 
 
@@ -187,8 +199,9 @@ def _perform_dir_incantations(path: Path):
         if sub_path.is_dir():
             continue
         with sub_path.open("rb") as file_handle:
+            # DCM has a 128 byte pre-amble followed by "DICM"
             header = file_handle.read(128 + 4)
-        if Spell(b"DICM", 128).perform(header):
+        if Spell(b"DICM", offset=128).perform(header):
             return [("dicom",)]
     return []
 
@@ -222,7 +235,7 @@ def summon_file_types(
 ) -> List[Tuple[str, ...]]:
     """Perform a series of incantations to determine the file types.
 
-    A list of types is returned becuse the file may contain multiple
+    A list of types is returned because the file may contain multiple
     magic numbers or patterns. E.g. a file may be
 
     Args:

--- a/wsic/readers.py
+++ b/wsic/readers.py
@@ -774,7 +774,7 @@ class ZarrReader(Reader):
     """Reader for zarr files."""
 
     def __init__(
-        self, path: PathLike | zarr.storage.StoreLike, axes: Optional[str] = None
+        self, path: Union[PathLike, zarr.storage.StoreLike], axes: Optional[str] = None
     ) -> None:
         super().__init__(path)
         register_codecs()

--- a/wsic/readers.py
+++ b/wsic/readers.py
@@ -37,7 +37,7 @@ class Reader(ABC):
             path (PathLike):
                 Path to file.
         """
-        self.path = Path(path)
+        self.path = path
 
     @abstractmethod
     def __getitem__(self, index: Tuple[Union[int, slice], ...]) -> np.ndarray:
@@ -773,10 +773,12 @@ class OpenSlideReader(Reader):
 class ZarrReader(Reader):
     """Reader for zarr files."""
 
-    def __init__(self, path: PathLike, axes: Optional[str] = None) -> None:
+    def __init__(
+        self, path: PathLike | zarr.storage.StoreLike, axes: Optional[str] = None
+    ) -> None:
         super().__init__(path)
         register_codecs()
-        self.zarr = zarr.open(str(path), mode="r")
+        self.zarr = zarr.open(path, mode="r")
         # Currently mpp not stored in zarr, could use xarray metadata
         # for this or custom wsic metadata
         self.microns_per_pixel = None

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -1252,9 +1252,12 @@ class ZarrWriter(Writer, Reader):
         self.overwrite = overwrite
         register_codecs()
         self.compressor = self.get_codec(codec, compression_level)
+        # If only path is given, pass this to zarr.open
         if store is None:
             store = path
-        elif path is not None and path != store.path:
+        # Else check that if path is not None, it matches store.path (if
+        # store has a path attr).
+        elif path is not None and (not hasattr(store, "path") or path != store.path):
             raise ValueError(
                 "ZarrWriter path {path} not None and does not match "
                 f"store path {store.path}"

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -1259,8 +1259,7 @@ class ZarrWriter(Writer, Reader):
         # store has a path attr).
         elif path is not None and (not hasattr(store, "path") or path != store.path):
             raise ValueError(
-                "ZarrWriter path {path} not None and does not match "
-                f"store path {store.path}"
+                f"ZarrWriter path {path} not None and does not match " f"store {store}"
             )
         if store is None:
             raise ValueError("ZarrWriter requires either path or store")

--- a/wsic/writers.py
+++ b/wsic/writers.py
@@ -86,7 +86,7 @@ class Writer(ABC):
 
     def __init__(
         self,
-        path: PathLike,
+        path: Optional[PathLike],
         shape: Tuple[int, int],
         tile_size: Tuple[int, int] = (256, 256),
         dtype: np.dtype = np.uint8,
@@ -98,7 +98,7 @@ class Writer(ABC):
         overwrite: bool = False,
         verbose: bool = False,
     ):
-        self.path = Path(path)
+        self.path = Path(path) if path is not None else path
         self.shape = shape
         self.tile_size = tile_size
         self.dtype = dtype
@@ -112,7 +112,7 @@ class Writer(ABC):
         self.overwrite = overwrite
         self.verbose = verbose
 
-        if self.path.exists() and not self.overwrite:
+        if path is not None and self.path.exists() and not self.overwrite:
             raise FileExistsError(f"{self.path} already exists")
 
     def reader_tile_iterator(
@@ -1175,8 +1175,9 @@ class ZarrWriter(Writer, Reader):
     """Zarr reader and writer.
 
     Args:
-        path (PathLike):
-            Path to the output zarr.
+        path (PathLike, optional):
+            Path to the output zarr. May be None if `store` is
+            provided.
         shape (Tuple[int, int]):
             Shape of the output zarr.
         tile_size (Tuple[int, int], optional):
@@ -1206,12 +1207,19 @@ class ZarrWriter(Writer, Reader):
         ome (bool):
             Write OME-NGFF metadata. Defaults to False.
             Currently not implemented.
-
+        store (zarr.StoreLike, optional):
+            Zarr storage backend to use. Defaults to None, which passes
+            the `path` argument `zarr.open`. May be a string or a
+            zarr.StoreLike instance (e.g. MutableMapping). If None, the
+            path is passed to the `zarr.open` convenince function. See
+            https://zarr.readthedocs.io/en/stable/api/storage.html and
+            https://zarr.readthedocs.io/en/stable/api/convenience.html
+            for more information.
     """
 
     def __init__(
         self,
-        path: Path,
+        path: Optional[Path] = None,
         shape: Tuple[int, int] = None,
         tile_size: Tuple[int, int] = (256, 256),
         dtype: np.dtype = np.uint8,
@@ -1224,6 +1232,7 @@ class ZarrWriter(Writer, Reader):
         verbose: bool = False,
         *,
         ome: bool = False,
+        store: Optional[zarr.storage.StoreLike] = None,
     ) -> None:
         warn_unused(microns_per_pixel)
         super().__init__(
@@ -1243,7 +1252,16 @@ class ZarrWriter(Writer, Reader):
         self.overwrite = overwrite
         register_codecs()
         self.compressor = self.get_codec(codec, compression_level)
-        self.zarr = zarr.open(self.path, mode="a")
+        if store is None:
+            store = path
+        elif path is not None and path != store.path:
+            raise ValueError(
+                "ZarrWriter path {path} not None and does not match "
+                f"store path {store.path}"
+            )
+        if store is None:
+            raise ValueError("ZarrWriter requires either path or store")
+        self.zarr = zarr.open(store, mode="a")
         self.tile_shape = tile_size[::-1]
 
     @property
@@ -1598,6 +1616,11 @@ class ZarrWriter(Writer, Reader):
             "Currently only JPEG, J2K (JPEG-2000), and WebP compression "
             " are supported for transcoding."
         )
+
+    def close(self) -> None:
+        """Close the writer."""
+        if hasattr(self.zarr.store, "close"):
+            self.zarr.store.close()
 
 
 class ZarrIntermediate(Writer, Reader):


### PR DESCRIPTION
Adds support for using other zarr stores when reading and writing. A `zarr.StoreLike` object (e.g. a `MutableMapping`) may be passed e.g:

```python
writer = ZarrWriter(store=zarr.SQliteStore("mydb.sqlite"))
```

For the CLI, this can be specified with `--store=` e.g.:

```
wsic convert -i=... -o="mydb.sqlite" --store="sqlite"
wsic convert -i=... -o="output.zarr" --store="zip"
```