### PR TITLE
🐛 Add QOI To FIXED_LEVEL_CODECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ There are many other great tools in this space. Below are some other
 tools for converting WSIs.
 
 1. **[bfconvert](https://www.openmicroscopy.org/bio-formats/downloads/)**
-Part of the Bio-Formats command line tools. Uses bioformats to convert
-from many formats to OME-TIFF.
+   Part of the Bio-Formats command line tools. Uses bioformats to convert
+   from many formats to OME-TIFF.
 1. **[biofromats2raw](https://github.com/glencoesoftware/bioformats2raw)**
-Convert from Bio-Formats formats to zarr.
+   Convert from Bio-Formats formats to zarr.
 1. **[isyntax2raw](https://github.com/glencoesoftware/isyntax2raw)** Convert from Philips' iSyntax format to a zarr using Philips' SDK.
 1. **[wsidicomiser](https://github.com/sectra-medical/wsidicomizer)** Convert OpenSlide images to WSI DICOM.
 

--- a/wsic/enums.py
+++ b/wsic/enums.py
@@ -203,7 +203,7 @@ IMAGECODECS_CODECS = (
     Codec.LZW,
 )
 
-FIXED_LEVEL_CODECS = (Codec.LZ4, Codec.LZW, Codec.ZSTD)
+FIXED_LEVEL_CODECS = (Codec.LZ4, Codec.LZW, Codec.ZSTD, Codec.QOI)
 
 
 class ColorSpace(str, Enum):


### PR DESCRIPTION
Fixes a bug where using QOI compression with zarr would error because the `imagecodecs.numcodecs` codec class has no "level" kwarg when loaded using `from_config`.